### PR TITLE
Generate CHANGELOG with git-cliff and back-fill release history

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,14 +74,32 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v4
+
       - uses: actions/download-artifact@v4
         with:
           merge-multiple: true
+
+      - name: Extract changelog entry
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          # Pull this version's section out of CHANGELOG.md (heading until the
+          # next "## ["). Missing/empty is fine — the auto-generated notes below
+          # still populate the release body.
+          awk -v ver="$VERSION" '
+            $0 ~ "^## \\[" ver "\\]" { flag = 1; print; next }
+            flag && /^## \[/ { exit }
+            flag { print }
+          ' CHANGELOG.md > release-notes.md
+          echo "Release notes for $VERSION:"
+          cat release-notes.md
 
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
           files: git-aicommit-*
+          body_path: release-notes.md
           generate_release_notes: true
 
   publish:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.3.0](https://github.com/getkono/git-aicommit/releases/tag/v0.3.0) - 2026-05-18
+
+### Features
+
+- Run pre-commit hooks before AI call and forward extra args to git commit
+
+### Bug Fixes
+
+- Handle sed backup file in version bump command
+
+### Documentation
+
+- Document required Claude Code CLI version
+
+## [0.2.0](https://github.com/getkono/git-aicommit/releases/tag/v0.2.0) - 2026-04-19
+
+### Features
+
+- Add justfile for release automation
+
+### Documentation
+
+- Add development notes for tag management
+
+### Refactor
+
+- Remove test hook and improve code style
+- Move system prompt to constant and use CLI flag
+
+### CI/Build
+
+- Use rust-lang crates-io-auth-action for secure publishing
+
+### Miscellaneous
+
+- Exclude DEVELOPMENT.md from published package
+- Add development automation recipes and git hooks
+
+## [0.1.1](https://github.com/getkono/git-aicommit/releases/tag/v0.1.1) - 2026-04-10
+
+### Features
+
+- Add --model flag to select Claude model at runtime
+
+## [0.1.0](https://github.com/getkono/git-aicommit/releases/tag/v0.1.0) - 2026-04-10
+
+### Features
+
+- Add GitHub Actions CI/release workflows and update install docs
+- Parse JSON responses and display token usage metrics
+- Add progress spinners to CLI operations
+- Implement git-aicommit CLI tool
+
+### Miscellaneous
+
+- Add dual licenses
+- Add MIT License to the project

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,8 +1,43 @@
 # Development Notes
 
+## Releasing
+
+Releases are cut with the `just release` recipe, which requires
+[git-cliff](https://git-cliff.org) (`cargo install git-cliff`):
+
+```sh
+just release 0.4.0
+```
+
+This bumps the version in `Cargo.toml`/`Cargo.lock`, prepends a new section to
+`CHANGELOG.md` for the commits since the last tag, commits, creates an annotated
+`v0.4.0` tag, and pushes — which triggers the GitHub Actions release workflow
+(builds binaries, creates the GitHub release, publishes to crates.io).
+
+## Changelog
+
+`CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com) and is
+generated from [Conventional Commits](https://www.conventionalcommits.org) by
+git-cliff (configured in `cliff.toml`). The committed file lists released
+versions only — `just release` prepends each new section — so you rarely touch
+it by hand. Pending (not-yet-released) changes are viewed on demand rather than
+tracked in the file.
+
+```sh
+# See what the next release's section would look like (the unreleased commits):
+just changelog-preview
+
+# Rebuild the whole file from git history (repair / regenerate):
+just changelog
+```
+
+Commit subjects drive the grouping, so write them in Conventional Commits style
+(`feat:`, `fix:`, `docs:`, `refactor:`, `ci:`, …). `chore: bump version …` and
+merge commits are skipped automatically.
+
 ## Removing broken release/tag
 
-```
+```sh
 # Delete tag locally and remotely
 git tag -d v<ver>
 git push origin :refs/tags/v<ver>
@@ -11,6 +46,3 @@ git push origin :refs/tags/v<ver>
 git tag -a v<ver> -m "Release <ver>"
 git push origin v<ver>
 ```
-```
-```
-

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,87 @@
+# git-cliff configuration — generates CHANGELOG.md from Conventional Commits.
+# Docs: https://git-cliff.org/docs/configuration
+#
+#   just changelog-preview   # show the pending (unreleased) section
+#   just changelog           # rebuild CHANGELOG.md from scratch
+#   just release X.Y.Z       # cuts a release; prepends the new section here
+
+[changelog]
+# Rendered once at the top of the file.
+header = """
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+"""
+# Rendered once per release. `version` is unset for the unreleased section.
+# Headings link inline (rather than via reference-style footer links) so the
+# template stays self-contained — important for the prepend-based release flow.
+body = """
+{% if version -%}
+    ## [{{ version | trim_start_matches(pat="v") }}](https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+    ## [Unreleased]
+{% endif -%}
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | split(pat="\n") | first | upper_first | trim }}\
+    {% endfor %}
+{% endfor %}\n
+"""
+footer = ""
+# Strip leading/trailing whitespace from each rendered section.
+trim = true
+# Collapse any accidental run of blank lines down to a single one.
+postprocessors = [
+    { pattern = '\n{3,}', replace = "\n\n" },
+]
+
+[git]
+# Parse commits as Conventional Commits (feat:, fix:, ...).
+conventional_commits = true
+# Keep non-conventional commits too — the catch-all parser routes them to
+# Miscellaneous so nothing is silently dropped during the history backfill.
+filter_unconventional = false
+# Don't drop commits that match no parser (the catch-all handles them).
+filter_commits = false
+split_commits = false
+# Tags look like v0.1.0, v1.2.3, ...
+tag_pattern = "v[0-9]*"
+# Newest release first; newest commit first within a release.
+sort_commits = "newest"
+topo_order = false
+
+# Tidy subjects before grouping/rendering. `[ \t]*` (not `\s*`) so a trailing
+# "(closes #N)" is stripped without ever swallowing the newline into the body.
+commit_preprocessors = [
+    { pattern = '[ \t]*\(?(?i)(closes?|fixes?|resolves?)\s+#\d+\)?', replace = "" },
+]
+
+# First match wins. Numeric HTML-comment prefixes set group order; the template
+# strips them with `striptags`.
+commit_parsers = [
+    { message = "^Merge", skip = true },
+    { message = "^chore:?\\s*bump version", skip = true },
+    { message = "^chore\\(release\\)", skip = true },
+    { message = "^[Ii]nit$", skip = true },
+    { message = "^feat", group = "<!-- 0 -->Features" },
+    { message = "^fix", group = "<!-- 1 -->Bug Fixes" },
+    { message = "^perf", group = "<!-- 2 -->Performance" },
+    { message = "^docs", group = "<!-- 3 -->Documentation" },
+    { message = "^refactor", group = "<!-- 4 -->Refactor" },
+    { message = "^style", group = "<!-- 5 -->Styling" },
+    { message = "^test", group = "<!-- 6 -->Testing" },
+    { message = "^(ci|build)", group = "<!-- 7 -->CI/Build" },
+    { message = "^revert", group = "<!-- 8 -->Reverted" },
+    # Everything else (chore:, plain subjects like "Add dual licenses", ...).
+    { message = ".*", group = "<!-- 9 -->Miscellaneous" },
+]
+
+# Used to build heading/compare links without hitting the GitHub API.
+[remote.github]
+owner = "getkono"
+repo = "git-aicommit"

--- a/justfile
+++ b/justfile
@@ -23,6 +23,37 @@ setup:
     lefthook install
     cargo build
 
+# Preview the changelog section for the not-yet-released commits.
+changelog-preview:
+    @git cliff --unreleased
+
+# Rebuild CHANGELOG.md from scratch (released versions, from git history).
+changelog:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    # The committed changelog lists released versions only; `just release` adds
+    # each new section. This recipe rebuilds the whole file from git history
+    # (use `just changelog-preview` to see the not-yet-released section).
+    if ! command -v git-cliff >/dev/null 2>&1; then
+        echo "Error: git-cliff not found — install with: cargo install git-cliff"
+        exit 1
+    fi
+
+    ROOT="$(git rev-list --max-parents=0 HEAD | tail -1)"
+    LATEST_TAG="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+
+    if [ -n "$LATEST_TAG" ]; then
+        # Range up to the latest tag so an untagged merge at HEAD can't get
+        # mis-attributed to the latest tagged release.
+        git cliff "${ROOT}..${LATEST_TAG}" --output CHANGELOG.md
+    else
+        git cliff --output CHANGELOG.md
+    fi
+
+    # Trim the trailing blank lines git-cliff leaves at EOF.
+    printf '%s\n' "$(cat CHANGELOG.md)" > CHANGELOG.md.tmp && mv CHANGELOG.md.tmp CHANGELOG.md
+
 # Release: bump Cargo.toml version, commit, tag, and push to trigger GH Actions release workflow.
 # Usage: just release 0.2.0
 release version:
@@ -32,6 +63,12 @@ release version:
     # Validate semver-ish format
     if ! echo "{{version}}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
         echo "Error: version must be in X.Y.Z format (got '{{version}}')"
+        exit 1
+    fi
+
+    # git-cliff generates the changelog entry for this release
+    if ! command -v git-cliff >/dev/null 2>&1; then
+        echo "Error: git-cliff not found — install with: cargo install git-cliff"
         exit 1
     fi
 
@@ -55,7 +92,11 @@ release version:
     # Update Cargo.lock
     cargo update --workspace --precise "{{version}}" 2>/dev/null || cargo generate-lockfile
 
-    git add Cargo.toml Cargo.lock
+    # Prepend the changelog section for this release. --unreleased scopes to the
+    # not-yet-tagged commits; --tag labels that section with this version.
+    git cliff --tag "$TAG" --unreleased --prepend CHANGELOG.md
+
+    git add Cargo.toml Cargo.lock CHANGELOG.md
     git commit -m "chore: bump version to {{version}}"
 
     # Annotated tag triggers the release workflow


### PR DESCRIPTION
Adds a git-cliff–driven changelog flow that generates `CHANGELOG.md` from Conventional Commits and wires it into the release pipeline. Closes #10.

## Summary

- Introduce `cliff.toml` producing [Keep a Changelog](https://keepachangelog.com)–style output from Conventional Commits, grouped by type, with noise (version bumps, merges, `init`) skipped.
- Back-fill `CHANGELOG.md` for `v0.1.0`..`v0.3.0` from git history.
- The committed changelog lists released versions only; pending changes are viewed on demand via `just changelog-preview` rather than tracked in the file.

## Implementation

1. **`cliff.toml`**: Conventional-commit parsing with a catch-all that routes unconventional commits to *Miscellaneous* (nothing dropped during back-fill); inline heading links keep the template self-contained for the prepend-based flow.
2. **`just release`**: Now prepends the new release section (`git cliff --tag --unreleased --prepend`) alongside the version bump, commit, tag, and push.
3. **New recipes**: `just changelog` rebuilds the file from history (scoped to the latest tag); `just changelog-preview` shows the unreleased section.
4. **Release workflow**: Extracts the matching `CHANGELOG.md` section via `awk` and leads the GitHub release notes with it (`body_path`), falling back to auto-generated notes.
5. **Docs**: `DEVELOPMENT.md` documents the release and changelog flow.

## Followup

- Requires `git-cliff` installed locally (`cargo install git-cliff`) for the release/changelog recipes — both recipes guard on its presence.
