### PR TITLE
feat: add -V/--version reporting build metadata (closes #15)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,12 @@ jobs:
       - name: Build
         shell: bash
         run: |
+          # Bake real version metadata into the binary. Exported here, where git
+          # is available, then forwarded into the cross container (which has no
+          # git) via Cross.toml. build.rs falls back to probing locally when
+          # these are unset, so plain `cargo build` still works.
+          export GIT_AICOMMIT_COMMIT="$(git rev-parse --short HEAD)"
+          export GIT_AICOMMIT_BUILD_DATE="$(date -u '+%Y-%m-%d %H:%M:%S UTC')"
           if [[ "${{ matrix.use_cross }}" == "true" ]]; then
             cross build --release --target ${{ matrix.target }}
           else

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://github.com/getkono/git-aicommit"
 readme = "README.md"
 keywords = ["git", "commit", "ai", "claude", "cli"]
 categories = ["command-line-utilities", "development-tools"]
-exclude = ["target/", "/.github", "DEVELOPMENT.md"]
+exclude = ["target/", "/.github", "/Cross.toml", "DEVELOPMENT.md"]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,9 @@
+# Forward the version metadata exported by the release workflow into the cross
+# build container (which has no `git`), so the cross-compiled Linux binaries
+# report a real commit hash and build date. See `build.rs` and the Build step in
+# `.github/workflows/release.yml`.
+[build.env]
+passthrough = [
+    "GIT_AICOMMIT_COMMIT",
+    "GIT_AICOMMIT_BUILD_DATE",
+]

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ git aicommit
 
 Your editor opens with the AI-generated message. Save to commit, or quit with an empty message to abort.
 
-`git aicommit` aims to be a drop-in for `git commit`: it understands the common flags and forwards anything else straight through. Pass `--model` (if you use it) before any git flags; run `git aicommit --help` for a summary.
+`git aicommit` aims to be a drop-in for `git commit`: it understands the common flags and forwards anything else straight through. Pass `--model` (if you use it) before any git flags; run `git aicommit --help` for a summary, or `git aicommit --version` to print the version, build metadata, and binary path.
 
 ### Supported flags
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,87 @@
+//! Build script: bake the commit hash, build date, and build profile into the
+//! binary so `git aicommit --version` can report them.
+//!
+//! Every value degrades to `"unknown"` rather than failing the build, because
+//! the source isn't always present: a `cargo install` from crates.io has no
+//! `.git`, and the cross container that builds the Linux release artifacts has
+//! no `git` at all. To give those Linux binaries a real hash and date anyway,
+//! the release workflow exports `GIT_AICOMMIT_COMMIT`/`GIT_AICOMMIT_BUILD_DATE`
+//! (where `git` *is* available) and forwards them into the container via
+//! `Cross.toml`; the env override below takes precedence over the local probes.
+
+use std::path::Path;
+use std::process::Command;
+
+fn main() {
+    emit_commit_hash();
+    emit_build_date();
+    emit_build_profile();
+}
+
+/// Short commit hash: a CI-provided `GIT_AICOMMIT_COMMIT`, else `git`, else
+/// `"unknown"`. Watching `HEAD` keeps incremental local builds fresh after a
+/// commit or checkout.
+fn emit_commit_hash() {
+    println!("cargo:rerun-if-env-changed=GIT_AICOMMIT_COMMIT");
+    watch_git_head();
+
+    let hash = env_override("GIT_AICOMMIT_COMMIT")
+        .or_else(|| run("git", &["rev-parse", "--short", "HEAD"]))
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=GIT_AICOMMIT_COMMIT_HASH={hash}");
+}
+
+/// Build timestamp (UTC): a CI-provided `GIT_AICOMMIT_BUILD_DATE`, else `date`,
+/// else `"unknown"`.
+fn emit_build_date() {
+    println!("cargo:rerun-if-env-changed=GIT_AICOMMIT_BUILD_DATE");
+    let date = env_override("GIT_AICOMMIT_BUILD_DATE")
+        .or_else(|| run("date", &["-u", "+%Y-%m-%d %H:%M:%S UTC"]))
+        .unwrap_or_else(|| "unknown".to_string());
+    println!("cargo:rustc-env=GIT_AICOMMIT_BUILD_DATE={date}");
+}
+
+/// Cargo's build profile (`"debug"`/`"release"`); always set during a build.
+fn emit_build_profile() {
+    let profile = std::env::var("PROFILE").unwrap_or_else(|_| "unknown".to_string());
+    println!("cargo:rustc-env=GIT_AICOMMIT_BUILD_PROFILE={profile}");
+}
+
+/// A trimmed, non-empty environment variable, or `None` if unset or blank.
+fn env_override(key: &str) -> Option<String> {
+    std::env::var(key)
+        .ok()
+        .map(|v| v.trim().to_string())
+        .filter(|v| !v.is_empty())
+}
+
+/// Run a command, returning its trimmed stdout on success and `None` otherwise
+/// (binary missing, non-zero exit, or empty output).
+fn run(cmd: &str, args: &[&str]) -> Option<String> {
+    let out = Command::new(cmd).args(args).output().ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    (!s.is_empty()).then_some(s)
+}
+
+/// Re-run when the checked-out commit changes, so an incremental build after a
+/// commit/checkout re-reads the hash. Best effort: skipped for linked worktrees
+/// (`.git` is a file) and packaged sources (no `.git`), where the env override
+/// or `git` probe still supplies the value.
+fn watch_git_head() {
+    let head = Path::new(".git/HEAD");
+    if !head.is_file() {
+        return;
+    }
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    if let Ok(content) = std::fs::read_to_string(head)
+        && let Some(reference) = content.strip_prefix("ref: ")
+    {
+        let ref_path = format!(".git/{}", reference.trim());
+        if Path::new(&ref_path).is_file() {
+            println!("cargo:rerun-if-changed={ref_path}");
+        }
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,6 +22,27 @@ pub(crate) struct Args {
     pub(crate) git_args: Vec<String>,
 }
 
+/// The multi-line `--version` report: the semver line, the build metadata baked
+/// in by `build.rs`, and the path of the running binary (resolved at runtime).
+pub(crate) fn version() -> String {
+    let binary = std::env::current_exe()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| "unknown".to_string());
+    format!(
+        "\
+git-aicommit {version}
+  commit:   {commit}
+  built:    {built}
+  profile:  {profile}
+  binary:   {binary}
+",
+        version = env!("CARGO_PKG_VERSION"),
+        commit = env!("GIT_AICOMMIT_COMMIT_HASH"),
+        built = env!("GIT_AICOMMIT_BUILD_DATE"),
+        profile = env!("GIT_AICOMMIT_BUILD_PROFILE"),
+    )
+}
+
 pub(crate) const HELP: &str = "\
 git-aicommit — draft a commit message from your changes with Claude, then open `git commit`.
 
@@ -30,6 +51,7 @@ USAGE:
 
 HANDLED BY git-aicommit:
     --model <name>      Claude model to use (default: haiku). Must come first.
+    -V, --version       Print version, build metadata, and binary path, then exit.
     -m, --message <s>   Steer the AI with an instruction (NOT a literal message). Repeatable.
     -t, --template <f>  Make the AI follow the format/structure in file <f>.
     -a, --all           Include all tracked changes (diff vs HEAD); also forwarded to git.
@@ -41,7 +63,8 @@ HANDLED BY git-aicommit:
 
 FORWARDED to `git commit` verbatim:
     -e/--edit (on by default), -n/--no-verify, -s/--signoff, -S/--gpg-sign,
-    --author, --date, --allow-empty, and any other flags you pass.
+    -v/--verbose (note: -V is our version flag), --author, --date,
+    --allow-empty, and any other flags you pass.
 
 BYPASS (no AI; runs plain `git commit`):
     --fixup, --squash, -C/--reuse-message, -c/--reedit-message, -F/--file

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -53,6 +53,12 @@ pub(crate) fn wants_help(git_args: &[String]) -> bool {
     git_args.iter().any(|a| a == "-h" || a == "--help")
 }
 
+/// `true` if the user asked for the version (`-V`/`--version`). We deliberately
+/// do *not* claim `-v`: that's git's `--verbose`, which we forward untouched.
+pub(crate) fn wants_version(git_args: &[String]) -> bool {
+    git_args.iter().any(|a| a == "-V" || a == "--version")
+}
+
 /// `true` if the user supplied a message from another commit/file (`--fixup`,
 /// `--squash`, `-C`/`-c`/`-F` and their long forms). There is nothing for the AI
 /// to generate, so we hand the original args straight to `git commit`.
@@ -467,5 +473,26 @@ mod tests {
         assert!(!bypass(&["-am", "x"])); // `m` consumes the rest; no C/c/F flag
         assert!(!bypass(&["file.js"]));
         assert!(!bypass(&[]));
+    }
+
+    fn version(args: &[&str]) -> bool {
+        wants_version(&args.iter().map(|s| s.to_string()).collect::<Vec<_>>())
+    }
+
+    #[test]
+    fn version_flag() {
+        assert!(version(&["-V"]));
+        assert!(version(&["--version"]));
+        assert!(version(&["-a", "--version"])); // recognized anywhere, like --help
+        assert!(!version(&[]));
+        assert!(!version(&["-a"]));
+        // `-v` is git's --verbose, not our version flag.
+        assert!(!version(&["-v"]));
+    }
+
+    #[test]
+    fn verbose_is_forwarded_not_intercepted() {
+        // `-v` must reach `git commit` untouched (it's --verbose, not --version).
+        assert_eq!(parse(&["-v"]).passthrough, v(&["-v"]));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,10 @@ fn run(model: &str, git_args: &[String]) -> Result<()> {
         print!("{}", cli::HELP);
         return Ok(());
     }
+    if flags::wants_version(git_args) {
+        print!("{}", cli::version());
+        return Ok(());
+    }
     if flags::is_bypass(git_args) {
         return git::run_git_commit_passthrough(git_args);
     }


### PR DESCRIPTION
Closes #15.

Adds a `-V` / `--version` command that prints the version, commit hash, build profile, compilation date, and binary path, then exits.

```
git-aicommit 0.3.1
  commit:   dd0d747
  built:    2026-05-29 04:51:01 UTC
  profile:  release
  binary:   /usr/local/bin/git-aicommit
```

## Design notes

- **`-V`, not `-v`.** The issue offered either. `git commit -v` (`--verbose`) is forwarded to git verbatim today, so version is bound to `-V`/`--version` (the cargo/clap convention) to avoid breaking that passthrough. A test locks in that `-v` is still forwarded.
- **Mirrors `--help`.** Handled as a no-AI short-circuit in `run()` via a new `flags::wants_version` predicate, next to `wants_help`. No tokens spent.
- **Build metadata via `build.rs`.** Commit hash / build date / profile are baked in with `cargo:rustc-env`. Every value degrades to `"unknown"` rather than failing the build (a `cargo install` from crates.io has no `.git`). `.git/HEAD` + the active ref are watched so the hash refreshes after a commit/checkout.
- **Cross-compiled release artifacts.** The Linux/musl targets build inside a `cross` container with no `git`, which would otherwise emit `"unknown"`. The release workflow exports the hash/date where `git` is available and forwards them into the container via a new `Cross.toml`; the env override takes precedence over the local probe.

## Changes

| File | Change |
|---|---|
| `build.rs` *(new)* | Bake in commit/date/profile; graceful fallbacks; watch HEAD. |
| `Cross.toml` *(new)* | Forward metadata env vars into the cross container. |
| `.github/workflows/release.yml` | Export `GIT_AICOMMIT_COMMIT`/`_BUILD_DATE` in the Build step. |
| `src/cli.rs` | `version()` renderer + `-V` documented in `HELP`. |
| `src/flags.rs` | `wants_version()` + tests. |
| `src/main.rs` | No-AI short-circuit. |
| `Cargo.toml` / `README.md` | Exclude `Cross.toml` from the crate; document `--version`. |

## Verification

`cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test` (32 pass, 2 new), debug + release builds. Confirmed the env-override path and the HEAD-watching refresh both work.