### PR TITLE
feat: add `--push` flag to push after a successful commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ git aicommit --no-verify --signoff
 git aicommit --dry-run         # print the diff + generated message, then exit
 ```
 
+**Push after committing:**
+
+```sh
+git aicommit -a --push         # run `git push` once the commit succeeds
+```
+
+`--push` runs a bare `git push` (so git uses the branch's configured upstream/remote) only after the commit goes through — if you abort the commit or it fails, nothing is pushed.
+
 **Bypass the AI entirely** — when the message already comes from elsewhere, git handles the commit directly with no API call:
 
 ```sh

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -59,6 +59,7 @@ HANDLED BY git-aicommit:
         --interactive   Interactively stage via `git add -i` first.
         --amend         Regenerate the message for an amended commit (prev message + combined diff).
         --dry-run       Print the diff and generated message, then exit without committing.
+        --push          Run `git push` after the commit succeeds.
     <pathspec>...       Limit the commit (and the AI's context) to these paths.
 
 FORWARDED to `git commit` verbatim:

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -20,6 +20,8 @@ pub(crate) struct ParsedArgs {
     pub(crate) amend: bool,
     pub(crate) interactive: Option<Interactive>,
     pub(crate) dry_run: bool,
+    /// Run `git push` after a successful commit (our own flag, not `git commit`'s).
+    pub(crate) push: bool,
     pub(crate) no_edit: bool,
     pub(crate) no_verify: bool,
     pub(crate) allow_empty: bool,
@@ -131,6 +133,9 @@ pub(crate) fn classify_args(git_args: &[String]) -> Result<ParsedArgs> {
                 "patch" => p.interactive = Some(Interactive::Patch),
                 "interactive" => p.interactive = Some(Interactive::Interactive),
                 "dry-run" => p.dry_run = true,
+                // Our own flag: `git push` after a successful commit. Not a
+                // `git commit` flag, so it is intercepted and never forwarded.
+                "push" => p.push = true,
                 "edit" => {} // we always add `-e` ourselves
                 "no-edit" => {
                     p.no_edit = true;
@@ -367,6 +372,20 @@ mod tests {
         assert_eq!(parse(&["-s"]).passthrough, v(&["-s"]));
         assert_eq!(parse(&["--signoff"]).passthrough, v(&["--signoff"]));
         assert!(parse(&["--dry-run"]).dry_run);
+    }
+
+    #[test]
+    fn push_flag() {
+        let p = parse(&["--push"]);
+        assert!(p.push);
+        // `--push` is ours; it must not leak through to `git commit`.
+        assert!(p.passthrough.is_empty());
+        // Off by default.
+        assert!(!parse(&[]).push);
+        // Travels alongside other flags without being forwarded.
+        let p = parse(&["-a", "--push"]);
+        assert!(p.all && p.push);
+        assert_eq!(p.passthrough, v(&["-a"]));
     }
 
     #[test]

--- a/src/git.rs
+++ b/src/git.rs
@@ -331,6 +331,25 @@ pub(crate) fn final_commit(commit_args: &[String]) -> Result<()> {
     Ok(())
 }
 
+/// Run `git push` after a successful commit (for `--push`), inheriting stdio so
+/// credential prompts and progress are visible. Issues a bare `git push`, so git
+/// decides the destination from the branch's configured upstream/remote —
+/// exactly as running `git push` by hand would.
+pub(crate) fn push() -> Result<()> {
+    eprintln!("\npushing…");
+    let status = Command::new("git")
+        .arg("push")
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .map_err(|e| Error::Git(format!("failed to run `git push`: {e}")))?;
+    if !status.success() {
+        return Err(Error::Git(format!("`git push` exited with {status}")));
+    }
+    Ok(())
+}
+
 /// Run `git commit` with the user's raw args, inheriting stdio. Used for bypass
 /// modes (`--fixup`, `-C`, …) where there's nothing for the AI to generate.
 pub(crate) fn run_git_commit_passthrough(git_args: &[String]) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,5 +117,12 @@ fn run(model: &str, git_args: &[String]) -> Result<()> {
         eprintln!("\nopening editor to review commit message…");
     }
     let commit_args = git::build_commit_args(&message, &p, early_check);
-    git::final_commit(&commit_args)
+    git::final_commit(&commit_args)?;
+
+    // 10. Push, if asked. Only reached when the commit succeeded (an aborted or
+    //     failed `git commit` returns above), so we never push without a commit.
+    if p.push {
+        git::push()?;
+    }
+    Ok(())
 }


### PR DESCRIPTION
## Summary

Implements #20: adds a `--push` flag that automatically runs `git push` after a successful commit.

```sh
git aicommit -a --push
```

## Behavior

- Runs a **bare `git push`** after the commit succeeds, so git uses the branch's configured upstream/remote — same as running `git push` by hand. No `--force`, no remote/branch guessing.
- `--push` is **intercepted** by git-aicommit and never forwarded to `git commit` (it isn't a real `git commit` flag).
- Only pushes when the commit actually goes through: an aborted commit (empty editor message), a failed commit, or `--dry-run` never push, because those return before the push step.
- stdio is inherited, so credential prompts and push progress are visible.

## Changes

- `flags.rs` — new `push` field on `ParsedArgs`; parse `--push`; unit tests.
- `git.rs` — new `push()` helper.
- `main.rs` — push after `final_commit` succeeds.
- `cli.rs` / `README.md` — document the flag.

## Testing

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (35 passed), `cargo build --release` all pass locally.

Closes #20