### PR TITLE
feat: add `-y/--yes` to commit without opening the editor (closes #22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ git aicommit --no-verify --signoff
 git aicommit --dry-run         # print the diff + generated message, then exit
 ```
 
+**Commit without reviewing:**
+
+```sh
+git aicommit -y                # commit the generated message directly, no editor
+```
+
+`-y`/`--yes` skips the editor review and commits the generated message as-is. It
+does **not** skip hooks — use `-n`/`--no-verify` for that.
+
 **Push after committing:**
 
 ```sh
@@ -124,5 +133,5 @@ git aicommit -- --weird-filename
 ## Notes
 
 - The prompt asks for Conventional Commits style (`feat:`, `fix:`, etc.), imperative subject ≤72 chars, optional body explaining the *why*.
-- By default the editor opens so you can review before committing; quit with an empty message to abort. `--no-edit` commits the generated message directly, and `--dry-run` never commits.
+- By default the editor opens so you can review before committing; quit with an empty message to abort. `-y`/`--yes` (or `--no-edit`) commits the generated message directly, and `--dry-run` never commits.
 - No API key handling here; auth is delegated entirely to the `claude` CLI.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -59,6 +59,7 @@ HANDLED BY git-aicommit:
         --interactive   Interactively stage via `git add -i` first.
         --amend         Regenerate the message for an amended commit (prev message + combined diff).
         --dry-run       Print the diff and generated message, then exit without committing.
+    -y, --yes           Commit the generated message directly, without opening the editor.
         --push          Run `git push` after the commit succeeds.
     <pathspec>...       Limit the commit (and the AI's context) to these paths.
 

--- a/src/flags.rs
+++ b/src/flags.rs
@@ -22,6 +22,9 @@ pub(crate) struct ParsedArgs {
     pub(crate) dry_run: bool,
     /// Run `git push` after a successful commit (our own flag, not `git commit`'s).
     pub(crate) push: bool,
+    /// Commit the generated message directly, skipping the editor review (our own
+    /// `-y`/`--yes` flag, not a `git commit` flag, so it is never forwarded).
+    pub(crate) yes: bool,
     pub(crate) no_edit: bool,
     pub(crate) no_verify: bool,
     pub(crate) allow_empty: bool,
@@ -47,6 +50,12 @@ impl ParsedArgs {
     /// commit working-tree content that may differ from the index.
     pub(crate) fn commits_index(&self) -> bool {
         !self.all && !self.scoped()
+    }
+
+    /// True when we should commit the generated message directly instead of
+    /// opening the editor — either the friendly `-y`/`--yes` or git's `--no-edit`.
+    pub(crate) fn skip_editor(&self) -> bool {
+        self.yes || self.no_edit
     }
 }
 
@@ -136,6 +145,9 @@ pub(crate) fn classify_args(git_args: &[String]) -> Result<ParsedArgs> {
                 // Our own flag: `git push` after a successful commit. Not a
                 // `git commit` flag, so it is intercepted and never forwarded.
                 "push" => p.push = true,
+                // Our own flag: commit the generated message directly, skipping
+                // the editor. Not a `git commit` flag, so it is never forwarded.
+                "yes" => p.yes = true,
                 "edit" => {} // we always add `-e` ourselves
                 "no-edit" => {
                     p.no_edit = true;
@@ -196,6 +208,9 @@ pub(crate) fn classify_args(git_args: &[String]) -> Result<ParsedArgs> {
                         p.passthrough.push("-n".to_string());
                     }
                     'p' => p.interactive = Some(Interactive::Patch),
+                    // Our own flag: skip the editor and commit directly. Like
+                    // `--push`/`-y`, intercepted and never forwarded to git.
+                    'y' => p.yes = true,
                     'm' | 't' => {
                         let rest = &body[idx + c.len_utf8()..];
                         let v = if rest.is_empty() {
@@ -385,6 +400,27 @@ mod tests {
         // Travels alongside other flags without being forwarded.
         let p = parse(&["-a", "--push"]);
         assert!(p.all && p.push);
+        assert_eq!(p.passthrough, v(&["-a"]));
+    }
+
+    #[test]
+    fn yes_flag() {
+        let p = parse(&["--yes"]);
+        assert!(p.yes && p.skip_editor());
+        // `-y`/`--yes` are ours; they must not leak through to `git commit`.
+        assert!(p.passthrough.is_empty());
+        let p = parse(&["-y"]);
+        assert!(p.yes && p.skip_editor());
+        assert!(p.passthrough.is_empty());
+        // Off by default, and `--no-edit` still drives skip_editor too.
+        assert!(!parse(&[]).yes && !parse(&[]).skip_editor());
+        assert!(parse(&["--no-edit"]).skip_editor());
+        // Combines in short bundles without being forwarded.
+        let p = parse(&["-ay"]);
+        assert!(p.all && p.yes);
+        assert_eq!(p.passthrough, v(&["-a"]));
+        let p = parse(&["-ya"]);
+        assert!(p.all && p.yes);
         assert_eq!(p.passthrough, v(&["-a"]));
     }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -292,7 +292,7 @@ fn is_executable_file(path: &Path) -> bool {
 /// Assemble the final `git commit …` argument vector.
 pub(crate) fn build_commit_args(message: &str, p: &ParsedArgs, add_no_verify: bool) -> Vec<String> {
     let mut args = vec!["commit".to_string()];
-    if !p.no_edit {
+    if !p.skip_editor() {
         args.push("-e".to_string());
     }
     args.push("-m".to_string());
@@ -424,6 +424,18 @@ mod tests {
         };
         let a = build_commit_args("hi", &p, false);
         assert_eq!(a, v(&["commit", "-m", "hi", "--no-edit"]));
+        assert!(!a.contains(&"-e".to_string()));
+    }
+
+    #[test]
+    fn commit_args_yes_skips_editor() {
+        // `-y` skips `-e` like `--no-edit`, but is never forwarded to git.
+        let p = ParsedArgs {
+            yes: true,
+            ..Default::default()
+        };
+        let a = build_commit_args("hi", &p, false);
+        assert_eq!(a, v(&["commit", "-m", "hi"]));
         assert!(!a.contains(&"-e".to_string()));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,8 +110,9 @@ fn run(model: &str, git_args: &[String]) -> Result<()> {
         return Ok(());
     }
 
-    // 9. Hand off to `git commit` so the user can review/edit (unless --no-edit).
-    if p.no_edit {
+    // 9. Hand off to `git commit` so the user can review/edit (unless the editor
+    //    is skipped via `-y`/`--yes` or `--no-edit`).
+    if p.skip_editor() {
         eprintln!();
     } else {
         eprintln!("\nopening editor to review commit message…");


### PR DESCRIPTION
Closes #22.

## What

Adds a `-y`/`--yes` flag: `git aicommit -y` generates the message and commits it
directly, without opening the editor to review.

## How

The tool only ever opens an editor because `build_commit_args` adds `-e`. `-y`
simply suppresses that, so `git commit -m "<msg>"` runs without `-e` and never
opens an editor — for plain **and** `--amend` commits.

- `-y`/`--yes` is **our own** flag (like `--push`): intercepted and never
  forwarded to `git`. Previously a bare `-y` was forwarded as an unknown short
  flag that `git commit` rejects, so claiming it is also a small fix.
- It unifies with the existing `--no-edit` behavior through a new
  `ParsedArgs::skip_editor()` helper (`self.yes || self.no_edit`), used by
  `build_commit_args` and the "opening editor…" message.

## Decision

"Without checking" here means the **editor review** step only. `-y` does **not**
skip pre-commit hooks — that is already `-n`/`--no-verify`'s job, and conflating
the two would be surprising.

## Tests

- `flags::tests::yes_flag` — `-y`/`--yes` set `yes`, drive `skip_editor()`, are
  not forwarded, and combine in short bundles (`-ay`, `-ya`).
- `git::tests::commit_args_yes_skips_editor` — `-y` omits `-e` from the commit args.
- Full gate green locally: `cargo fmt --check`, `cargo clippy --all-targets -D warnings`,
  `cargo test`, `cargo build --release`. `--help` lists the new flag.