### PR TITLE
feat: auto-select model and effort from diff size (closes #17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # git-aicommit
 
 A tiny Rust CLI that drafts a commit message from your staged changes using
-[Claude Code](https://docs.claude.com/en/docs/claude-code) (Haiku), then opens
+[Claude Code](https://docs.claude.com/en/docs/claude-code), then opens
 `git commit` with the message pre-filled so you can review, edit, or abort.
+The model is picked automatically from the diff size — Haiku for everyday
+commits, Sonnet for large ones — or pinned with `--model`.
 
 ## How it works
 
 1. Parses standard `git commit` flags (see [Supported flags](#supported-flags)) to decide what to diff and how to prompt.
 2. Checks you're in a git repo and that there's something to commit.
 3. For plain and `--amend` commits, runs the `pre-commit` hook as an early check (`git hook run` on Git ≥ 2.36, executing the hook script directly on older git) — if it fails, the tool aborts before making any API call. (For `-a` and pathspec commits the staged index isn't what gets committed, so hooks run at commit time instead.)
-4. Feeds the relevant diff to `claude -p --model haiku` over stdin.
+4. Picks a model from the diff size (Haiku by default; Sonnet with higher effort for large or many-file diffs, announced on its own line) unless you pin one with `--model`, then feeds the relevant diff to `claude -p` over stdin.
 5. Cleans up the response and runs `git commit -e -m "<message>" …`, inheriting your terminal so `$EDITOR` opens normally.
 
 Large diffs are truncated at 60KB to keep the prompt sane.
@@ -65,7 +67,7 @@ git aicommit
 
 Your editor opens with the AI-generated message. Save to commit, or quit with an empty message to abort.
 
-`git aicommit` aims to be a drop-in for `git commit`: it understands the common flags and forwards anything else straight through. Pass `--model` (if you use it) before any git flags; run `git aicommit --help` for a summary, or `git aicommit --version` to print the version, build metadata, and binary path.
+`git aicommit` aims to be a drop-in for `git commit`: it understands the common flags and forwards anything else straight through. By default it auto-selects the model from the diff size (`haiku`, or `sonnet` with higher effort for large/many-file diffs, announced when it isn't haiku); pass `--model <name>` to pin one (before any git flags). Run `git aicommit --help` for a summary, or `git aicommit --version` to print the version, build metadata, and binary path.
 
 ### Supported flags
 

--- a/src/claude.rs
+++ b/src/claude.rs
@@ -46,23 +46,55 @@ impl Generated {
     }
 }
 
+/// Diffs at or above this many bytes escalate from haiku to a stronger model.
+const ESCALATE_DIFF_BYTES: usize = 16_000;
+/// Diffs touching at least this many files escalate too — many small, unrelated
+/// changes are exactly where a single-pass summary tends to drop detail.
+const ESCALATE_FILE_COUNT: usize = 8;
+
+/// Choose the model (and thinking effort) for a diff of the given size, used when
+/// the user didn't pin one with `--model`. Small diffs stay on fast, cheap haiku
+/// at the default effort; large or many-file diffs escalate to sonnet with
+/// `medium` effort so secondary changes aren't lost in the summary.
+pub(crate) fn auto_select(
+    diff_len: usize,
+    file_count: usize,
+) -> (&'static str, Option<&'static str>) {
+    if diff_len >= ESCALATE_DIFF_BYTES || file_count >= ESCALATE_FILE_COUNT {
+        ("sonnet", Some("medium"))
+    } else {
+        ("haiku", None)
+    }
+}
+
 /// Run `claude` in non-interactive print mode with minimal context, feeding the
-/// payload on stdin, and return the cleaned message plus usage stats.
-pub(crate) fn generate(model: &str, system_prompt: &str, payload: &str) -> Result<Generated> {
+/// payload on stdin, and return the cleaned message plus usage stats. When
+/// `effort` is `Some`, it is passed through as `--effort <level>`.
+pub(crate) fn generate(
+    model: &str,
+    effort: Option<&str>,
+    system_prompt: &str,
+    payload: &str,
+) -> Result<Generated> {
+    let mut args = vec![
+        "-p",
+        "--model",
+        model,
+        "--output-format",
+        "json",
+        "--tools",
+        "",
+        "--no-session-persistence",
+        "--disable-slash-commands",
+        "--system-prompt",
+        system_prompt,
+    ];
+    if let Some(level) = effort {
+        args.push("--effort");
+        args.push(level);
+    }
     let mut child = Command::new("claude")
-        .args([
-            "-p",
-            "--model",
-            model,
-            "--output-format",
-            "json",
-            "--tools",
-            "",
-            "--no-session-persistence",
-            "--disable-slash-commands",
-            "--system-prompt",
-            system_prompt,
-        ])
+        .args(&args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -168,6 +200,25 @@ mod tests {
         assert_eq!(clean_message("```\nhello\n```"), "hello");
         assert_eq!(clean_message("```text\nhello\nworld\n```"), "hello\nworld");
         assert_eq!(clean_message("  hello  "), "hello");
+    }
+
+    #[test]
+    fn auto_select_tiers() {
+        // Small diff, few files → haiku, default effort.
+        assert_eq!(auto_select(0, 0), ("haiku", None));
+        assert_eq!(
+            auto_select(ESCALATE_DIFF_BYTES - 1, ESCALATE_FILE_COUNT - 1),
+            ("haiku", None)
+        );
+        // Either threshold (size or file count) escalates to sonnet + effort.
+        assert_eq!(
+            auto_select(ESCALATE_DIFF_BYTES, 1),
+            ("sonnet", Some("medium"))
+        );
+        assert_eq!(
+            auto_select(100, ESCALATE_FILE_COUNT),
+            ("sonnet", Some("medium"))
+        );
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,9 +11,10 @@ use clap::Parser;
 )]
 pub(crate) struct Args {
     /// Claude model to use (passed directly to `claude --model`).
-    /// Must come before any git flags.
-    #[arg(long, default_value = "haiku")]
-    pub(crate) model: String,
+    /// Must come before any git flags. When omitted, the model is chosen
+    /// automatically from the diff size (see `claude::auto_select`).
+    #[arg(long)]
+    pub(crate) model: Option<String>,
 
     /// Standard `git commit` flags. Recognized flags steer how the message is
     /// generated; everything else is forwarded verbatim to `git commit`.
@@ -50,7 +51,9 @@ USAGE:
     git aicommit [--model <name>] [git commit flags] [-- <pathspec>...]
 
 HANDLED BY git-aicommit:
-    --model <name>      Claude model to use (default: haiku). Must come first.
+    --model <name>      Claude model to use. Must come first. When omitted, it is
+                        chosen automatically: haiku for small diffs, sonnet (with
+                        higher effort) for large or many-file ones.
     -V, --version       Print version, build metadata, and binary path, then exit.
     -m, --message <s>   Steer the AI with an instruction (NOT a literal message). Repeatable.
     -t, --template <f>  Make the AI follow the format/structure in file <f>.

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use spinner::Spinner;
 
 fn main() {
     let args = Args::parse();
-    if let Err(e) = run(&args.model, &args.git_args) {
+    if let Err(e) = run(args.model.as_deref(), &args.git_args) {
         eprintln!("error: {e}");
         std::process::exit(1);
     }
@@ -22,8 +22,9 @@ fn main() {
 
 /// Orchestrate the whole flow: classify flags, read the diff, build the prompt,
 /// ask Claude for a message, then hand off to `git commit`. Each phase delegates
-/// to a focused module; this function just sequences them.
-fn run(model: &str, git_args: &[String]) -> Result<()> {
+/// to a focused module; this function just sequences them. `user_model` is the
+/// explicit `--model`, or `None` to auto-pick from the diff size.
+fn run(user_model: Option<&str>, git_args: &[String]) -> Result<()> {
     // 0. Short-circuits that do no AI work.
     if flags::wants_help(git_args) {
         print!("{}", cli::HELP);
@@ -52,15 +53,33 @@ fn run(model: &str, git_args: &[String]) -> Result<()> {
     // 3. Read the diff for the AI, matching what the commit will record.
     let base = git::resolve_base(&p)?;
     let diff_args = git::build_diff_args(&p, &base);
-    let diff = {
+    let (diff, file_count) = {
         let sp = Spinner::new("reading changes…");
         let d = git::read_diff(&p, &diff_args)?;
         sp.finish(format!("changes ready  ({} file(s))", d.file_count));
-        d.text
+        (d.text, d.file_count)
     };
 
     // 4. Truncate the diff if it's huge, on a char boundary so we never split UTF-8.
     let diff_for_prompt = prompt::truncate_diff(&diff);
+
+    // 4b. Resolve the model: honor an explicit `--model`, otherwise auto-pick from
+    //     the full (pre-truncation) diff size and file count. Announce an
+    //     escalation away from haiku prominently, on its own line.
+    let (model, effort): (String, Option<&str>) = match user_model {
+        Some(m) => (m.to_string(), None),
+        None => {
+            let (m, e) = claude::auto_select(diff.len(), file_count);
+            if m != "haiku" {
+                let effort_note = e.map(|lvl| format!(" (effort {lvl})")).unwrap_or_default();
+                eprintln!(
+                    "auto-selected model: {m}{effort_note} — large diff ({}, {file_count} file(s))",
+                    fmt_size(diff.len()),
+                );
+            }
+            (m.to_string(), e)
+        }
+    };
 
     // 5. Early pre-commit hook check — only when the index equals what we'll
     //    commit (plain/amend/interactive). For `-a` and pathspec(`--only`) modes
@@ -94,7 +113,7 @@ fn run(model: &str, git_args: &[String]) -> Result<()> {
     // 7. Run claude in non-interactive print mode with minimal context.
     let message = {
         let sp = Spinner::new(&format!("generating commit message with claude {model}…"));
-        let generated = claude::generate(model, &system_prompt, &payload)?;
+        let generated = claude::generate(&model, effort, &system_prompt, &payload)?;
         sp.finish(format!(
             "commit message generated  ({})",
             generated.metrics_line()
@@ -125,4 +144,26 @@ fn run(model: &str, git_args: &[String]) -> Result<()> {
         git::push()?;
     }
     Ok(())
+}
+
+/// Human-readable byte size for the auto-model notice, e.g. 48128 -> "47 KB".
+fn fmt_size(bytes: usize) -> String {
+    if bytes >= 1024 {
+        format!("{} KB", bytes / 1024)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fmt_size_units() {
+        assert_eq!(fmt_size(0), "0 B");
+        assert_eq!(fmt_size(1023), "1023 B");
+        assert_eq!(fmt_size(1024), "1 KB");
+        assert_eq!(fmt_size(48_128), "47 KB");
+    }
 }


### PR DESCRIPTION
Closes #17.

## What

Haiku was the hard-coded default. Now `--model` is **optional**: when omitted,
the model (and thinking effort) is chosen automatically from the diff size, and
an escalation away from Haiku is shown prominently.

## Decisions (with justification)

- **Auto only when `--model` is absent.** `cli::Args.model` becomes
  `Option<String>` so an explicit `--model` is always honored verbatim and never
  triggers escalation or the notice.
- **Two tiers, by diff size *and* file count.** Byte size alone misses the
  "many tiny unrelated files" case, and `file_count` is already computed in
  `read_diff`. Escalate when `diff.len() >= 16_000` **or** `file_count >= 8`:
  - small → **haiku**, no explicit `--effort` (identical to today — zero
    regression on the common path).
  - large → **sonnet** `--effort medium`. Sonnet handles multi-file diffs far
    better; `medium` improves coverage of secondary changes without the
    latency/cost of `high` for a non-critical task. (The `claude` CLI accepts
    `--effort {low,medium,high,xhigh,max}`.)
  - Size is the **full**, pre-truncation diff, so a 200 KB diff truncated to
    60 KB still reads as "large".
  - Thresholds are named constants (`ESCALATE_DIFF_BYTES`, `ESCALATE_FILE_COUNT`).
- **Prominent notice** only when auto picks non-haiku, e.g.
  `auto-selected model: sonnet (effort medium) — large diff (47 KB, 12 file(s))`,
  on its own line before the spinner.

## How

- `claude::auto_select(diff_len, file_count) -> (model, effort)` — pure, tested.
- `claude::generate` gains an `effort: Option<&str>` arg → `--effort <level>`.
- `main::run` keeps the diff's `file_count`, resolves the effective model after
  the diff is read, and prints the notice via a small `fmt_size` helper.

## Tests

- `claude::tests::auto_select_tiers` — both thresholds (size and file count) at
  their boundaries.
- `tests::fmt_size_units` — byte→KB formatting for the notice.
- Full gate green: `cargo fmt --check`, `cargo clippy --all-targets -D warnings`,
  `cargo test`, `cargo build --release`.

> Note: scoped to model/effort *selection*. Surfacing the picked model is also
> handled (the notice + the existing `claude <model>…` spinner line).