### PR TITLE
fix: keep small/unrelated changes in generated commit messages (closes #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,5 +124,6 @@ git aicommit -- --weird-filename
 ## Notes
 
 - The prompt asks for Conventional Commits style (`feat:`, `fix:`, etc.), imperative subject ≤72 chars, optional body explaining the *why*.
+- When a commit bundles several unrelated changes, the message leads with the primary one in the subject and itemizes the rest as body bullets. A `git diff --stat` inventory of every changed file is sent alongside the diff so small or buried changes aren't dropped.
 - By default the editor opens so you can review before committing; quit with an empty message to abort. `--no-edit` commits the generated message directly, and `--dry-run` never commits.
 - No API key handling here; auth is delegated entirely to the `claude` CLI.

--- a/src/git.rs
+++ b/src/git.rs
@@ -109,6 +109,38 @@ pub(crate) fn build_diff_args(p: &ParsedArgs, base: &str) -> Vec<String> {
     args
 }
 
+/// Build the `git diff --stat …` argument vector, mirroring [`build_diff_args`]'s
+/// cached/scope decisions so the inventory matches what the commit records.
+pub(crate) fn build_diff_stat_args(p: &ParsedArgs, base: &str) -> Vec<String> {
+    let working_tree = p.interactive.is_none() && (p.all || !p.pathspecs.is_empty());
+    let mut args = vec!["diff".to_string()];
+    if !working_tree {
+        args.push("--cached".to_string());
+    }
+    args.push("--stat".to_string());
+    args.push("--no-color".to_string());
+    args.push(base.to_string());
+    if p.scoped() {
+        args.push("--".to_string());
+        args.extend(p.pathspecs.iter().cloned());
+    }
+    args
+}
+
+/// Run `git diff --stat …` and return the changed-file inventory (trimmed), or an
+/// empty string on any failure. Best-effort: this header enriches the prompt but
+/// must never block a commit, so errors are swallowed.
+pub(crate) fn read_diff_stat(p: &ParsedArgs, base: &str) -> String {
+    let args = build_diff_stat_args(p, base);
+    let Ok(out) = Command::new("git").args(&args).output() else {
+        return String::new();
+    };
+    if !out.status.success() {
+        return String::new();
+    }
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
 /// The diff text plus the number of files it touches.
 pub(crate) struct Diff {
     pub(crate) text: String,
@@ -520,6 +552,34 @@ mod tests {
         assert_eq!(
             build_diff_args(&inter, "HEAD"),
             v(&["diff", "--cached", "--no-color", "HEAD"])
+        );
+    }
+
+    #[test]
+    fn diff_stat_args_mirror_diff_args() {
+        // Same cached/scope decisions as build_diff_args, with `--stat`.
+        let plain = ParsedArgs::default();
+        assert_eq!(
+            build_diff_stat_args(&plain, "HEAD"),
+            v(&["diff", "--cached", "--stat", "--no-color", "HEAD"])
+        );
+
+        let all = ParsedArgs {
+            all: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            build_diff_stat_args(&all, "HEAD"),
+            v(&["diff", "--stat", "--no-color", "HEAD"])
+        );
+
+        let path = ParsedArgs {
+            pathspecs: v(&["f"]),
+            ..Default::default()
+        };
+        assert_eq!(
+            build_diff_stat_args(&path, "HEAD"),
+            v(&["diff", "--stat", "--no-color", "HEAD", "--", "f"])
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,11 @@ fn run(model: &str, git_args: &[String]) -> Result<()> {
         d.text
     };
 
+    // 3b. Read the changed-file inventory (`git diff --stat`) as a complete
+    //     checklist, so a small change buried in — or truncated out of — a large
+    //     diff is still surfaced to the model. Best-effort: empty on failure.
+    let diff_stat = git::read_diff_stat(&p, &base);
+
     // 4. Truncate the diff if it's huge, on a char boundary so we never split UTF-8.
     let diff_for_prompt = prompt::truncate_diff(&diff);
 
@@ -89,7 +94,7 @@ fn run(model: &str, git_args: &[String]) -> Result<()> {
     } else {
         None
     };
-    let payload = prompt::build_stdin_payload(&diff_for_prompt, prev_msg.as_deref());
+    let payload = prompt::build_stdin_payload(&diff_for_prompt, &diff_stat, prev_msg.as_deref());
 
     // 7. Run claude in non-interactive print mode with minimal context.
     let message = {

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -13,6 +13,11 @@ Rules:\n\
 - First line: imperative mood, <= 72 chars, no trailing period.\n\
 - Then a blank line.\n\
 - Then an optional short body (wrapped at ~72 chars) explaining the WHY, not the what.\n\
+- The change may bundle several unrelated edits; do NOT omit the smaller ones. \
+Put the primary change in the subject, then list every other notable or \
+unrelated change as a body bullet (- ...) so none are dropped.\n\
+- When a \"Changed files\" inventory (git diff --stat) precedes the diff, treat it \
+as a checklist: every file with a substantive change should be reflected in the message.\n\
 - Output ONLY the commit message. No code fences, no preamble, no explanation.";
 
 /// Cap the diff we feed Claude so we don't blow the context window / token budget.
@@ -44,13 +49,25 @@ pub(crate) fn build_system_prompt(p: &ParsedArgs, template_contents: Option<&str
     prompt
 }
 
-/// The stdin payload for Claude: the diff, prefixed with the previous commit
-/// message when amending.
-pub(crate) fn build_stdin_payload(diff: &str, prev_msg: Option<&str>) -> String {
-    match prev_msg {
-        Some(m) => format!("Previous commit message:\n{}\n\n---\n\n{diff}", m.trim()),
-        None => diff.to_string(),
+/// The stdin payload for Claude: the diff, prefixed with a changed-file inventory
+/// (`git diff --stat`) so no small change is overlooked, and with the previous
+/// commit message when amending. Empty sections are omitted.
+pub(crate) fn build_stdin_payload(diff: &str, stat: &str, prev_msg: Option<&str>) -> String {
+    let mut payload = String::new();
+    if let Some(m) = prev_msg {
+        payload.push_str(&format!(
+            "Previous commit message:\n{}\n\n---\n\n",
+            m.trim()
+        ));
     }
+    if !stat.trim().is_empty() {
+        payload.push_str(&format!(
+            "Changed files (git diff --stat):\n{}\n\n---\n\n",
+            stat.trim()
+        ));
+    }
+    payload.push_str(diff);
+    payload
 }
 
 /// Truncate the diff to [`MAX_DIFF_BYTES`] on a char boundary (so we never split
@@ -79,11 +96,23 @@ mod tests {
     }
 
     #[test]
-    fn stdin_payload_amend_prefix() {
-        assert_eq!(build_stdin_payload("DIFF", None), "DIFF");
-        let amend = build_stdin_payload("DIFF", Some("old msg\n"));
+    fn stdin_payload_blocks() {
+        // No stat, no previous message → just the diff.
+        assert_eq!(build_stdin_payload("DIFF", "", None), "DIFF");
+
+        // The stat is prepended as a labeled inventory before the diff.
+        let with_stat = build_stdin_payload("DIFF", " file | 2 +-", None);
+        assert!(with_stat.starts_with("Changed files (git diff --stat):\nfile | 2 +-\n\n---\n\n"));
+        assert!(with_stat.ends_with("DIFF"));
+
+        // Amend prefix comes first, then the inventory, then the diff.
+        let amend = build_stdin_payload("DIFF", "stat", Some("old msg\n"));
         assert!(amend.starts_with("Previous commit message:\nold msg\n\n---\n\n"));
+        assert!(amend.contains("Changed files (git diff --stat):\nstat\n\n---\n\n"));
         assert!(amend.ends_with("DIFF"));
+
+        // A blank/whitespace stat is omitted entirely.
+        assert_eq!(build_stdin_payload("DIFF", "   ", None), "DIFF");
     }
 
     #[test]


### PR DESCRIPTION
Closes #11.

## Problem

When a commit bundles a few small, unrelated changes into a larger one, the
generated message often mentions only the headline change and silently drops the
rest.

## Root cause

Two compounding factors:
1. The system prompt asked for a single subject + an *optional* "why" body — it
   never told the model to account for *distinct* changes, so the model wrote
   about the dominant one.
2. On a large/multi-file diff the model latches onto the headline change, and a
   small change buried deep (or truncated past the 60 KB cap) is easy to miss.

## Fix (cheap, no extra API call)

1. **Inventory header** — `git::read_diff_stat` prepends a `git diff --stat`
   summary of *every* changed file to the payload, so even a change truncated out
   of the patch body still appears as a checklist item. It mirrors
   `build_diff_args`' cached/scope decisions and is best-effort (empty on
   failure → never blocks a commit).
2. **Prompt rules** — the system prompt now tells the model to treat the
   inventory as a checklist and to surface secondary/unrelated changes as body
   bullets so none are omitted.

Rejected alternatives: a per-file map/reduce two-pass (too much latency/cost for
a tiny CLI) and raising the 60 KB cap (doesn't help the common "buried small
change" case).

## Tests

- `git::tests::diff_stat_args_mirror_diff_args` — stat args track the diff args
  across plain / `-a` / pathspec modes.
- `prompt::tests::stdin_payload_blocks` — inventory is prepended (and amend
  prefix ordering), whitespace-only stat omitted.
- `prompt::tests::system_prompt_blocks` still passes with the new rules.
- Full gate green: `cargo fmt --check`, `cargo clippy --all-targets -D warnings`,
  `cargo test`, `cargo build --release`.